### PR TITLE
Carry patch for skipping diskDiffOperation when cloning

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -902,8 +902,10 @@ func resourceVSphereVirtualMachineCustomizeDiff(d *schema.ResourceDiff, meta int
 
 	// Validate and normalize disk sub-resources when not deploying from ovf
 	if len(d.Get("ovf_deploy").([]interface{})) == 0 {
-		if err := virtualdevice.DiskDiffOperation(d, client); err != nil {
-			return err
+		if len(d.Get("clone").([]interface{})) == 0 {
+			if err := virtualdevice.DiskDiffOperation(d, client); err != nil {
+				return err
+			}
 		}
 	}
 	// When a VM is a member of a vApp container, it is no longer part of the VM


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1825323 we need to carry the patch from upstream PR: terraform-providers#1075