### PR TITLE
UPSTREAM 1161: Ignore thin_provisioned and eagerly_scrub during DiskPostCloneOperation

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1008,7 +1008,7 @@ func DiskPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.
 			//
 			// TODO: Remove "name" after 2.0.
 			switch k {
-			case "label", "path", "name", "datastore_id", "uuid":
+			case "label", "path", "name", "datastore_id", "uuid", "thin_provisioned", "eagerly_scrub":
 				continue
 			case "io_share_count":
 				if src["io_share_level"] != string(types.SharesLevelCustom) {


### PR DESCRIPTION
Carry patch from https://github.com/hashicorp/terraform-provider-vsphere/pull/1161